### PR TITLE
fix: use Next export output for Capacitor sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,17 +121,20 @@ npm run start         # serve the production build locally
 Mobile packaging bundle (static export consumed by Capacitor):
 
 ```bash
-npm run build:app
-npm run export        # outputs to apps/web/out
+npm run build:app     # builds and exports to apps/web/out, then syncs native shells when available
 ```
 
-After exporting, continue with Capacitor tooling (to be completed in later phases):
+After the export step completes, continue with Capacitor tooling (to be completed in later phases):
 
 ```bash
-npx cap copy
+npx cap copy          # copies apps/web/out into each added native shell
 npx cap open ios
 npx cap open android
 ```
+
+> ℹ️ `npm run build:app` now runs `next build` followed by `next export`, then triggers `scripts/sync-static-export.mjs` to copy
+> the generated contents of `apps/web/out` into any existing Capacitor platforms (Android/iOS). If you need to re-sync without
+> rebuilding, run `npm run sync:static`.
 
 ### Environment configuration
 

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "dev:app": "NEXT_PUBLIC_BUILD_TARGET=app next dev apps/web",
     "build": "npm run build:web",
     "build:web": "NEXT_PUBLIC_BUILD_TARGET=web next build apps/web",
-    "build:app": "NEXT_PUBLIC_BUILD_TARGET=app next build apps/web",
+    "build:app": "NEXT_PUBLIC_BUILD_TARGET=app next build apps/web && npm run export",
     "start": "NEXT_PUBLIC_BUILD_TARGET=web next start apps/web",
     "start:app": "NEXT_PUBLIC_BUILD_TARGET=app next start apps/web",
     "export": "NEXT_PUBLIC_BUILD_TARGET=app next export apps/web --outdir apps/web/out",
+    "postexport": "node scripts/sync-static-export.mjs",
+    "sync:static": "node scripts/sync-static-export.mjs",
     "lint": "next lint apps/web",
     "format": "prettier --write .",
     "type-check": "tsc --project apps/web/tsconfig.json --noEmit"

--- a/scripts/sync-static-export.mjs
+++ b/scripts/sync-static-export.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const exportDir = path.join(repoRoot, 'apps', 'web', 'out');
+
+const capacitorTargets = [
+  {
+    platform: 'android',
+    assetsDir: path.join(repoRoot, 'mobile', 'android', 'app', 'src', 'main', 'assets'),
+    outputDir: path.join(repoRoot, 'mobile', 'android', 'app', 'src', 'main', 'assets', 'public'),
+  },
+  {
+    platform: 'ios',
+    assetsDir: path.join(repoRoot, 'mobile', 'ios', 'App', 'App'),
+    outputDir: path.join(repoRoot, 'mobile', 'ios', 'App', 'App', 'public'),
+  },
+];
+
+async function pathExists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+async function main() {
+  if (!(await pathExists(exportDir))) {
+    console.error(
+      `Static export directory not found at "${path.relative(repoRoot, exportDir)}". ` +
+        'Run "npm run export" or "npm run build:app" first.'
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const copyPromises = capacitorTargets.map(async ({ platform, assetsDir, outputDir }) => {
+    if (!(await pathExists(assetsDir))) {
+      console.warn(
+        `Skipping ${platform} sync – expected assets directory missing at "${path.relative(
+          repoRoot,
+          assetsDir
+        )}". Run "npx cap add ${platform}" if this platform should be synced.`
+      );
+      return false;
+    }
+
+    await fs.rm(outputDir, { recursive: true, force: true });
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.cp(exportDir, outputDir, { recursive: true });
+
+    console.log(
+      `Synced static export from "${path.relative(repoRoot, exportDir)}" to "${path.relative(
+        repoRoot,
+        outputDir
+      )}".`
+    );
+    return true;
+  });
+
+  const results = await Promise.all(copyPromises);
+
+  if (!results.some(Boolean)) {
+    console.warn('No Capacitor platforms were synced. This is expected when no native shells exist yet.');
+  }
+}
+
+main().catch((error) => {
+  console.error('Failed to sync static export:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## 問題描述
- 既有同步腳本複製 `.next` 內容，導致 Capacitor 平台無法取得 Next.js `next export` 的真正靜態檔案。

## 重現步驟
1. 執行 `npm run build:app`。
2. 透過舊腳本同步靜態資源至 `mobile/android` 或 `mobile/ios`。
3. 啟動 Capacitor 容器時發現缺少 `apps/web/out` 的輸出。

## 根因分析
- 專案缺乏使用 Next.js 匯出 (`apps/web/out`) 的同步流程，仍嘗試複製 `.next` 產物，造成 Capacitor 無法載入靜態頁面。

## 解法摘要
- 新增 `scripts/sync-static-export.mjs`，僅將 `apps/web/out` 靜態內容同步到已建立的原生平台資料夾。
- 將 `build:app` 腳本串接 `next export`，並透過 `postexport` 自動觸發同步流程，另提供 `npm run sync:static` 供手動執行。
- 更新 README，說明新的輸出與同步步驟。

## 風險等級
- [x] 低
- [ ] 中
- [ ] 高

## 回滾步驟
- Revert 此次變更或還原 `package.json`、`README.md` 與 `scripts/` 目錄至前一版本。

## 測試證據
- [ ] 單元測試：
- [ ] 端對端測試：
- [ ] Lint：
- [ ] 型別檢查：
- [x] 其他（請說明）：`npm run build:app`、`npx cap copy` 嘗試受制於環境無法存取 npm registry（403 Forbidden），僅能記錄失敗狀態。

## 相關工單連結
-

------
https://chatgpt.com/codex/tasks/task_e_68d221a7ef248321b251370f816a9dde