### PR TITLE
fix: guard android build when no cordova plugins

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -39,7 +39,12 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    implementation project(':capacitor-cordova-android-plugins')
+    def cordovaPluginsProject = rootProject.findProject(':capacitor-cordova-android-plugins')
+    if (cordovaPluginsProject != null) {
+        implementation cordovaPluginsProject
+    } else {
+        logger.lifecycle('Skipping dependency on :capacitor-cordova-android-plugins because the project is not available.')
+    }
 }
 
 apply from: 'capacitor.build.gradle'

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -7,7 +7,12 @@ android {
   }
 }
 
-apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
+def cordovaVariables = file("../capacitor-cordova-android-plugins/cordova.variables.gradle")
+if (cordovaVariables.exists()) {
+  apply from: cordovaVariables
+} else {
+  logger.lifecycle("Skipping Cordova plugin variables gradle script because ${cordovaVariables.path} was not found.")
+}
 dependencies {
 
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,5 +1,10 @@
 include ':app'
-include ':capacitor-cordova-android-plugins'
-project(':capacitor-cordova-android-plugins').projectDir = new File('./capacitor-cordova-android-plugins/')
+def cordovaPluginsDir = file('capacitor-cordova-android-plugins')
+if (cordovaPluginsDir.exists()) {
+    include ':capacitor-cordova-android-plugins'
+    project(':capacitor-cordova-android-plugins').projectDir = cordovaPluginsDir
+} else {
+    logger.lifecycle("Skipping inclusion of :capacitor-cordova-android-plugins because ${cordovaPluginsDir.path} was not found.")
+}
 
 apply from: 'capacitor.settings.gradle'


### PR DESCRIPTION
## Summary
- guard the generated capacitor build script so the Android build no longer fails when the Cordova plugin bundle is absent
- conditionally include the capacitor Cordova plugin project in settings.gradle and dependency wiring
- log helpful messages instead of hard failures when the optional plugin directory is missing

## Testing
- `./gradlew assembleDebug` *(fails: missing Android SDK in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d57351df608321a5cbabf431f2a684