### PR TITLE
Configure Codemagic Android workflow for signed bundle

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -87,6 +87,10 @@ workflows:
       java: 17
       vars:
         CI: 'true'
+        CM_KEYSTORE: Encrypted(keystore)
+        CM_KEYSTORE_PASSWORD: Encrypted(password)
+        CM_KEY_ALIAS: upload
+        CM_KEY_PASSWORD: Encrypted(password)
     cache:
       cache_paths:
         - $HOME/.npm
@@ -98,6 +102,10 @@ workflows:
       - name: Build and sync static export
         script: |
           npm run build:app
+      - name: Decode Android keystore
+        script: |
+          echo $CM_KEYSTORE | base64 --decode > $CM_BUILD_DIR/upload-keystore.jks
+          cp $CM_BUILD_DIR/upload-keystore.jks android/app/upload-keystore.jks
       - name: Build Android APK
         script: |
           cd android
@@ -108,7 +116,7 @@ workflows:
           ./gradlew bundleRelease
     artifacts:
       - android/app/build/outputs/**/*.apk
-      - android/app/build/outputs/**/*.aab
+      - android/app/build/outputs/bundle/release/app-release.aab
     publishing:
       email:
         recipients:


### PR DESCRIPTION
## Summary
- add keystore environment variables and decoding step to the Android workflow
- ensure the release bundle task runs and collect the signed AAB artifact path

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68d93bab35b883218ca0d13eda24ce8d